### PR TITLE
利用する色を変数で定義

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,9 @@
  *= require_self
  */
 
+@import "shared/colors";
+
 .body {
   margin: 0px;
+  color: $navy-D;
 }

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,3 +1,5 @@
+@import "shared/colors";
+
 .header {
   width: 100%;
   text-align: center;
@@ -14,7 +16,7 @@
 
   .header__sub-menu {
     width: 100%;
-    background-color: #60bbc8;
+    background-color: $green;
     margin: 25px 0 0;
     text-align: center;
     padding: 0px;
@@ -25,16 +27,16 @@
     font-size: 15px;
     padding: 0 10px;
     height: 50px;
+  }
 
-    .header__sub-menu-item:hover {
-      background-color: #42849a;
-    }
+  .header__sub-menu-item:hover {
+    background-color: $green-D;
   }
 
   .header__sub-menu-link {
     display: inline-block;
     text-decoration: none;
-    color: #ffffff;
+    color: $white;
     height: 50px;
     line-height: 50px;
   }

--- a/app/assets/stylesheets/shared/_colors.scss
+++ b/app/assets/stylesheets/shared/_colors.scss
@@ -1,0 +1,57 @@
+$gold-D: #816938;
+$gold: #ac8c4b;
+$gold-1S: #c6ae7d;
+$gold-2S: #d4c29d;
+$gold-3S: #e2d6bd;
+$gold-4S: #f0eadd;
+$gold-5S: #f9f7f2;
+
+$green-D: #269e87;
+$green: #2fc3a7;
+$green-1S: #58d7bf;
+$green-2S: #8ae3d2;
+$green-3S: #afece0;
+$green-4S: #d4f5ee;
+$green-5S: #f5fcfb;
+
+$navy-D: #3b4b5b;
+$navy: #536a80;
+$navy-1S: #8198ae;
+$navy-2S: #b0becc;
+$navy-3S: #dee4ea;
+$navy-4S: #f1f3f6;
+$navy-5S: #f8f9fa;
+
+$white: #ffffff;
+
+$pink-D: #ff3265;
+$pink: #ff658b;
+$pink-1S: #ff7698;
+$pink-2S: #ff98b2;
+$pink-3S: #ffbacb;
+$pink-4S: #ffdce5;
+$pink-5S: #ffedf1;
+
+$red-D: #e73613;
+$red: #f0684e;
+$red-1S: #f3836d;
+$red-2S: #f69e8c;
+$red-3S: #f9c6bb;
+$red-4S: #fce0db;
+$red-5S: #fdeeea;
+
+$orange-D: #e67300;
+$orange: #ff952b;
+$orange-1S: #ffa64d;
+$orange-2S: #ffbf80;
+$orange-3S: #ffd9b3;
+$orange-4S: #ffead5;
+$orange-5S: #fff2e6;
+
+$blue-D: #1298d1;
+$blue: #49beef;
+$blue-1S: #78cef3;
+$blue-2S: #97daf6;
+$blue-3S: #b6e5f9;
+$blue-4S: #d5f0fb;
+$blue-5S: #f5fbfe;

--- a/app/assets/stylesheets/shared/_errors.scss
+++ b/app/assets/stylesheets/shared/_errors.scss
@@ -1,9 +1,11 @@
+@import "shared/colors";
+
 .errors {
   margin-top: 20px;
 
   .errors__item {
     padding-left: 20px;
     font-size: 12px;
-    color: #ff502f;
+    color: $red;
   }
 }

--- a/app/assets/stylesheets/shared/_flash-message.scss
+++ b/app/assets/stylesheets/shared/_flash-message.scss
@@ -1,13 +1,15 @@
+@import "shared/colors";
+
 .flash-message {
   font-size: 13px;
   height: 23px;
 
   .flash-message__danger {
-    background-color: #fc9a86;
+    background-color: $red-3S;
   }
 
   .flash-message__success {
-    background-color: #7debae;
+    background-color: $green-3S;
   }
 
   .flash-message__container {

--- a/app/assets/stylesheets/users/_signup-admin.scss
+++ b/app/assets/stylesheets/users/_signup-admin.scss
@@ -1,14 +1,10 @@
 @import "shared/colors";
+@import "users/signup-mixin";
 
 .signup-admin {
-  margin: 50px auto 0;
-  width: 500px;
-  border: 1px solid $navy-3S;
-  border-radius: 8px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
+  @include signup-layout;
 
   .signup-admin__title {
-    border-bottom: 10px solid $orange;
-    padding: 10px 10px 5px;
+    @include signup-layout__title($orange);
   }
 }

--- a/app/assets/stylesheets/users/_signup-admin.scss
+++ b/app/assets/stylesheets/users/_signup-admin.scss
@@ -1,12 +1,14 @@
+@import "shared/colors";
+
 .signup-admin {
   margin: 50px auto 0;
   width: 500px;
-  border: 1px solid #74828F;
+  border: 1px solid $navy-3S;
   border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
 
   .signup-admin__title {
-    border-bottom: 10px solid #d43e30;
+    border-bottom: 10px solid $orange;
     padding: 10px 10px 5px;
   }
 }

--- a/app/assets/stylesheets/users/_signup-corporate.scss
+++ b/app/assets/stylesheets/users/_signup-corporate.scss
@@ -1,14 +1,10 @@
 @import "shared/colors";
+@import "users/signup-mixin";
 
 .signup-corporate {
-  margin: 50px auto 0;
-  width: 500px;
-  border: 1px solid $navy-3S;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  @include signup-layout;
 
   .signup-corporate__title {
-    border-bottom: 10px solid $blue;
-    padding: 10px 10px 5px;
+    @include signup-layout__title($blue);
   }
 }

--- a/app/assets/stylesheets/users/_signup-corporate.scss
+++ b/app/assets/stylesheets/users/_signup-corporate.scss
@@ -1,12 +1,14 @@
+@import "shared/colors";
+
 .signup-corporate {
   margin: 50px auto 0;
   width: 500px;
-  border: 1px solid #74828F;
+  border: 1px solid $navy-3S;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 
   .signup-corporate__title {
-    border-bottom: 10px solid #2D7DBC;
+    border-bottom: 10px solid $blue;
     padding: 10px 10px 5px;
   }
 }

--- a/app/assets/stylesheets/users/_signup-form.scss
+++ b/app/assets/stylesheets/users/_signup-form.scss
@@ -1,3 +1,5 @@
+@import "shared/colors";
+
 .signup-form{
   .signup-form__main {
     margin-top: 20px;
@@ -12,7 +14,8 @@
     height: 40px;
     padding: 5px 10px;
     margin: 10px 10px 15px;
-    background-color: #FFD034;
+    background-color: $pink;
+    color: $white;
     border-style: none;
     border-radius: 5px;
     font-size: 12px;
@@ -20,7 +23,7 @@
 
   .signup-form__field-container {
     display: flex;
-    border: 1px solid #e4e2e2;
+    border: 1px solid $navy-3S;
     margin: 5px 10px;
   }
 
@@ -35,11 +38,12 @@
   .signup-form__field::placeholder {
     padding: 10px;
     vertical-align: middle;
+    color: $navy-1S;
   }
 
   .signup-form__icon {
-    color: #757575;
-    background-color: #f0f0f0;
+    color: $navy;
+    background-color: $gold-5S;
     height: 33px;
     vertical-align: middle;
     padding: 0 10px;

--- a/app/assets/stylesheets/users/_signup-mixin.scss
+++ b/app/assets/stylesheets/users/_signup-mixin.scss
@@ -1,0 +1,12 @@
+@mixin signup-layout {
+  margin: 50px auto 0;
+  width: 500px;
+  border: 1px solid $navy-3S;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+}
+
+@mixin signup-layout__title($color) {
+  border-bottom: 10px solid $color;
+  padding: 10px 10px 5px;
+}

--- a/app/assets/stylesheets/users/_signup-personal.scss
+++ b/app/assets/stylesheets/users/_signup-personal.scss
@@ -1,14 +1,10 @@
 @import "shared/colors";
+@import "users/signup-mixin";
 
 .signup-personal {
-  margin: 50px auto 0;
-  width: 500px;
-  border: 1px solid $navy-3S;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  @include signup-layout;
 
   .signup-personal__title {
-    border-bottom: 10px solid $green-1S;
-    padding: 10px 10px 5px;
+    @include signup-layout__title($green-1S);
   }
 }

--- a/app/assets/stylesheets/users/_signup-personal.scss
+++ b/app/assets/stylesheets/users/_signup-personal.scss
@@ -1,12 +1,14 @@
+@import "shared/colors";
+
 .signup-personal {
   margin: 50px auto 0;
   width: 500px;
-  border: 1px solid #74828F;
+  border: 1px solid $navy-3S;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 
   .signup-personal__title {
-    border-bottom: 10px solid #28b486;
+    border-bottom: 10px solid $green-1S;
     padding: 10px 10px 5px;
   }
 }


### PR DESCRIPTION
close #13 

## やったこと
- 利用する色を統一
- shared/_colors.scssに色の変数定義
- すでにあるレイアウトを、変数で書き換え
- ついでに登録ページのmixinも作っちゃいました。

### 登録ページ
| 個人 | 法人 | 管理者 |
| -- | -- | -- |
| <img width="1012" alt="スクリーンショット 2019-08-23 13 52 14" src="https://user-images.githubusercontent.com/33307379/63567849-23603600-c5ae-11e9-9137-163c964e4a35.png"> | <img width="956" alt="スクリーンショット 2019-08-23 13 52 31" src="https://user-images.githubusercontent.com/33307379/63567855-29561700-c5ae-11e9-9e6e-7fca31741ab4.png"> | <img width="853" alt="スクリーンショット 2019-08-23 13 52 41" src="https://user-images.githubusercontent.com/33307379/63567861-2d823480-c5ae-11e9-8feb-a55eb7a89a51.png"> |

### flashメッセージ
| 成功 | 失敗 |
| -- | -- |
| <img width="904" alt="スクリーンショット 2019-08-23 13 53 19" src="https://user-images.githubusercontent.com/33307379/63567898-4f7bb700-c5ae-11e9-8407-2d8a9f1c124d.png"> | <img width="989" alt="スクリーンショット 2019-08-23 13 52 59" src="https://user-images.githubusercontent.com/33307379/63567905-530f3e00-c5ae-11e9-8c96-3f3419818585.png"> |



