### PR TITLE
ログイン画面のマークアップ

### DIFF
--- a/app/assets/stylesheets/sessions/_signin-form.scss
+++ b/app/assets/stylesheets/sessions/_signin-form.scss
@@ -1,0 +1,60 @@
+@import "shared/colors";
+@import "shared/form-container-mixin";
+
+.signin-form {
+  @include form-layout;
+
+  .signin-layout__title {
+    @include form-layout__title($gold-1S);
+  }
+
+  .signin-form__main {
+    margin-top: 20px;
+  }
+
+  .signin-form__field-container {
+    display: flex;
+    border: 1px solid $navy-3S;
+    margin: 5px 10px;
+  }
+
+  .signin-form__icon {
+    color: $navy;
+    background-color: $gold-5S;
+    height: 33px;
+    vertical-align: middle;
+    padding: 0 10px;
+    line-height: 33px;
+    font-size: 15px;
+  }
+
+  .signin-form__field {
+    width: 420px;
+    height: 30px;
+    outline: 0;
+    border: 0px;
+    padding-left: 15px;
+  }
+
+  .signin-form__field::placeholder {
+    padding: 10px;
+    vertical-align: middle;
+    color: $navy-1S;
+  }
+
+  .signin-form__button-container {
+    text-align: center;
+  }
+
+  .signin-form__button {
+    width: 150px;
+    height: 40px;
+    padding: 5px 10px;
+    margin: 10px 10px 15px;
+    background-color: $pink;
+    color: $white;
+    border-style: none;
+    border-radius: 5px;
+    font-size: 12px;
+  }
+}

--- a/app/assets/stylesheets/sessions/_signin-form.scss
+++ b/app/assets/stylesheets/sessions/_signin-form.scss
@@ -9,13 +9,13 @@
   }
 
   .signin-form__main {
-    margin-top: 20px;
+    margin-top: 50px;
   }
 
   .signin-form__field-container {
     display: flex;
     border: 1px solid $navy-3S;
-    margin: 5px 10px;
+    margin: 5px 50px 20px;
   }
 
   .signin-form__icon {
@@ -29,7 +29,7 @@
   }
 
   .signin-form__field {
-    width: 420px;
+    width: 300px;
     height: 30px;
     outline: 0;
     border: 0px;
@@ -50,7 +50,7 @@
     width: 150px;
     height: 40px;
     padding: 5px 10px;
-    margin: 10px 10px 15px;
+    margin: 20px 10px 50px;
     background-color: $pink;
     color: $white;
     border-style: none;

--- a/app/assets/stylesheets/shared/_form-container-mixin.scss
+++ b/app/assets/stylesheets/shared/_form-container-mixin.scss
@@ -1,4 +1,4 @@
-@mixin signup-layout {
+@mixin form-layout {
   margin: 50px auto 0;
   width: 500px;
   border: 1px solid $navy-3S;
@@ -6,7 +6,7 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 }
 
-@mixin signup-layout__title($color) {
+@mixin form-layout__title($color) {
   border-bottom: 10px solid $color;
   padding: 10px 10px 5px;
 }

--- a/app/assets/stylesheets/users/_signup-admin.scss
+++ b/app/assets/stylesheets/users/_signup-admin.scss
@@ -1,10 +1,10 @@
 @import "shared/colors";
-@import "users/signup-mixin";
+@import "shared/form-container-mixin";
 
 .signup-admin {
-  @include signup-layout;
+  @include form-layout;
 
   .signup-admin__title {
-    @include signup-layout__title($orange);
+    @include form-layout__title($orange);
   }
 }

--- a/app/assets/stylesheets/users/_signup-corporate.scss
+++ b/app/assets/stylesheets/users/_signup-corporate.scss
@@ -1,10 +1,10 @@
 @import "shared/colors";
-@import "users/signup-mixin";
+@import "shared/form-container-mixin";
 
 .signup-corporate {
-  @include signup-layout;
+  @include form-layout;
 
   .signup-corporate__title {
-    @include signup-layout__title($blue);
+    @include form-layout__title($blue);
   }
 }

--- a/app/assets/stylesheets/users/_signup-personal.scss
+++ b/app/assets/stylesheets/users/_signup-personal.scss
@@ -1,10 +1,10 @@
 @import "shared/colors";
-@import "users/signup-mixin";
+@import "shared/form-container-mixin";
 
 .signup-personal {
-  @include signup-layout;
+  @include form-layout;
 
   .signup-personal__title {
-    @include signup-layout__title($green-1S);
+    @include form-layout__title($green-1S);
   }
 }

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -4,13 +4,13 @@
       = image_tag "icon.png", alt: 'Mpay', width: '130px', class: 'icon'
   %ul.header__sub-menu
     %li.header__sub-menu-item
-      = link_to "TOP", "#", class: "header__sub-menu-link"
+      = link_to "TOP", "/", class: "header__sub-menu-link"
     %li.header__sub-menu-item
       = link_to "MPayで出来ること", "#", class: "header__sub-menu-link"
 
     %li.header__sub-menu-item
-      = link_to "新規登録", "#", class: "header__sub-menu-link"
+      = link_to "新規登録", new_users_personal_path, class: "header__sub-menu-link"
     %li.header__sub-menu-item
-      = link_to "ログイン", "#", class: "header__sub-menu-link"
+      = link_to "ログイン", sign_in_path, class: "header__sub-menu-link"
     %li.header__sub-menu-item
       = link_to "問い合わせ", "#", class: "header__sub-menu-link"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,6 +1,6 @@
 .signin-form
   .signin-layout__title
-    ログイン
+    Mpayアカウント
 
   = form_for :session, url: sessions_path do |f|
     .signin-form__main

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,6 +1,6 @@
 .signin-form
   .signin-layout__title
-    Mpayアカウント
+    MPayアカウント
 
   = form_for :session, url: sessions_path do |f|
     .signin-form__main

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,6 +1,16 @@
-= form_for :session, url: sessions_path do |f|
-  = f.label :email
-  = f.email_field :email
-  = f.label :password
-  = f.password_field :password
-  = f.submit
+.signin-form
+  .signin-layout__title
+    ログイン
+
+  = form_for :session, url: sessions_path do |f|
+    .signin-form__main
+      .signin-form__field-container
+        %span.material-icons.signin-form__icon email
+        = f.email_field :email, placeholder: "メールアドレス", class: "signin-form__field"
+
+      .signin-form__field-container
+        %span.material-icons.signin-form__icon lock
+        = f.password_field :password, placeholder: "パスワード", class: "signin-form__field"
+
+      .signin-form__button-container
+        = f.submit "ログイン", class: "signin-form__button"


### PR DESCRIPTION
## やったこと
- ログイン画面のマークアップ
- headerにリンク追加（`TOP: / `、`新規登録： new_users_personal_path`、`ログイン： sign_in`）

<img width="1198" alt="スクリーンショット 2019-08-23 15 39 45" src="https://user-images.githubusercontent.com/33307379/63572140-1860d200-c5bd-11e9-9dc5-eb0c9d84443a.png">


## その他
一旦ログイン画面は、個人・法人・管理者共に共通のものになってます。
問題が発生したら変更予定